### PR TITLE
Hadamard was missing

### DIFF
--- a/docs/source/start.rst
+++ b/docs/source/start.rst
@@ -282,7 +282,7 @@ allows us to declare classical memory regions so that we can receive data from t
     .. code:: python
 
         from pyquil import get_qc, Program
-        from pyquil.gates import CNOT, Z, MEASURE
+        from pyquil.gates import CNOT, Z, H, MEASURE
         from pyquil.api import local_forest_runtime
         from pyquil.quilbase import Declare
 


### PR DESCRIPTION
It was a Hadamard import missing.

It was preventing the program to be run.

Description
-----------

Insert your PR description here. Thanks for [contributing][contributing] to pyQuil! 🙂

Checklist
---------

- [ ] The PR targets the `rc` branch (**not** `master`).
- [ ] Commit messages are prefixed with one of the prefixes outlined in the [commit syntax checker][commit-syntax] (see `pattern` field).
- [ ] The above description motivates these changes.
- [ ] There is a unit test that covers these changes.
- [ ] All new and existing tests pass locally and on the PR's checks.
- [ ] Parameters and return values have type hints with [PEP 484 syntax][pep-484].
- [ ] Functions and classes have useful [Sphinx-style][sphinx] docstrings.
- [ ] All code follows [Black][black] style and obeys [`flake8`][flake8] conventions.
- [ ] (New Feature) The [docs][docs] have been updated accordingly.
- [ ] (Bugfix) The associated issue is referenced above using [auto-close keywords][auto-close].
- [ ] The [changelog][changelog] is updated, including author and PR number (@username, #1234).


[auto-close]: https://help.github.com/en/articles/closing-issues-using-keywords
[black]: https://black.readthedocs.io/en/stable/index.html
[changelog]: https://github.com/rigetti/pyquil/blob/master/CHANGELOG.md
[commit-syntax]: https://github.com/rigetti/pyquil/blob/master/.github/workflows/commit_syntax.yml
[contributing]: https://github.com/rigetti/pyquil/blob/master/CONTRIBUTING.md
[docs]: https://pyquil.readthedocs.io
[flake8]: http://flake8.pycqa.org
[pep-484]: https://www.python.org/dev/peps/pep-0484/
[sphinx]: https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html
